### PR TITLE
Make sure CONFIG_ZLIB is defined for libmatroska2

### DIFF
--- a/libmatroska2/matroska_config.h.in
+++ b/libmatroska2/matroska_config.h.in
@@ -1,6 +1,7 @@
 // for libmatroska2
 #cmakedefine CONFIG_LZO1X
 #cmakedefine CONFIG_BZLIB
+#cmakedefine CONFIG_ZLIB
 #cmakedefine CONFIG_NOCODEC_HELPER
 
 #define LIBMATROSKA2_PROJECT_VERSION T("@matroska2_VERSION_MAJOR@.@matroska2_VERSION_MINOR@.@matroska2_VERSION_PATCH@")


### PR DESCRIPTION
Hello,

I ran into a situation where a subtitle track in an MKV file was compressed with ZLIB by mkvmerge when splitting a file.

In this version of mkclean (and the official 0.9.0 source) CONFIG_ZLIB is not defined for libmatroska2 so zlib compression is not supported.

Without this change the my subtitle track blocks were simply ignored by mkclean and removed in the output file.

Cheers!